### PR TITLE
Improve datafetching

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13614,6 +13614,21 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "swr": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.2.0.tgz",
+      "integrity": "sha512-8IZCdM0deUPhDiqOmyaj0BsnNjav1fu83nD0d07PEAzOHOn+lxcJOxwXeDBShwF6qCeZ8u8ab+a2yXkjD8yT3A==",
+      "requires": {
+        "fast-deep-equal": "2.0.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,8 @@
     "react-scripts": "3.4.0",
     "react-tag-autocomplete": "^5.12.1",
     "react-text-mask": "^5.4.3",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "swr": "^0.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/web/src/components/featureModule.js
+++ b/web/src/components/featureModule.js
@@ -7,7 +7,7 @@ const FeatureModule = props => {
     <div className="module feature-module">
       <div className="feature-module__content">
         {props.m &&
-          props.m[0].features.map(f => <Feature key={f._key} feature={f} />)}
+          props.m.features.map(f => <Feature key={f._key} feature={f} />)}
       </div>
     </div>
   );

--- a/web/src/components/introModule.js
+++ b/web/src/components/introModule.js
@@ -13,11 +13,11 @@ const IntroModule = ({ m }) => {
       </div>
       <div className="intro-module__content">
         <span className="intro-module__logo">
-          {m && m[0].branding && m[0].branding}
+          {m && m.branding && m.branding}
         </span>
-        <h1 className="intro-module__title">{m && m[0].title && m[0].title}</h1>
+        <h1 className="intro-module__title">{m && m.title && m.title}</h1>
         <div className="intro-module__text">
-          {m && m[0].text && <BlockContent blocks={m[0].text} />}
+          {m && m.text && <BlockContent blocks={m.text} />}
         </div>
         <Button text={'Sign up'} light={false} link={'/signup'}/>
       </div>

--- a/web/src/components/socialModule.js
+++ b/web/src/components/socialModule.js
@@ -9,24 +9,24 @@ const SocialModule = ({ m }) => {
     <div className="module social-module">
       <div className="social-module__content">
         <h2 className="social-module__title">
-          {m && m[0].title && m[0].title}
+          {m && m.title && m.title}
         </h2>
         <div className="social-module__text">
-          {m && m[0].text && <BlockContent blocks={m[0].text} />}
+          {m && m.text && <BlockContent blocks={m.text} />}
         </div>
         <div className="social-module__buttons">
           <a
-            href={m && m[0].buttonBlueUrl}
+            href={m && m.buttonBlueUrl}
             className="social-module__button social-module__button--blue"
           >
-            <span>{m && m[0].buttonBlueText}</span>
+            <span>{m && m.buttonBlueText}</span>
             <img src={facebook} alt="facebook" />
           </a>
           <a
-            href={m && m[0].buttonGreyUrl}
+            href={m && m.buttonGreyUrl}
             className="social-module__button social-module__button--grey"
           >
-            <span>{m && m[0].buttonGreyText}</span>
+            <span>{m && m.buttonGreyText}</span>
             <img src={github} alt="github" />
           </a>
         </div>

--- a/web/src/components/supportModule.js
+++ b/web/src/components/supportModule.js
@@ -11,14 +11,14 @@ const SupportModule = ({ m }) => {
       <div className="support-module__content">
         <h1 className="support-module__title">
           {' '}
-          {m && m[0].title && m[0].title}
+          {m && m.title && m.title}
         </h1>
         <div className="support-module__text">
-          {m && m[0].text && <BlockContent blocks={m[0].text} />}
+          {m && m.text && <BlockContent blocks={m.text} />}
         </div>
         <div className="support-module__collaborators">
           {m &&
-            m[0].supporters.map(s => (
+            m.supporters.map(s => (
               <img
                 key={s._key}
                 className="feature-module__image"


### PR DESCRIPTION
Here is an alternative and a bit simpler way to deal with data-fetching using [swr](https://github.com/zeit/swr). I also refactored the query to return the first document for each type and removed the initial filter (GROQ lets you wrap queries in a root object). This means that you don't have to send in arrays in the modules and access the first element. 

I'm not sure the content model where you delegate different parts of the landing page to a _type is ideal? So that's something we might want to rethink before going too far. 